### PR TITLE
Fix handling of :443, fix a crash and don't show scary errors

### DIFF
--- a/client.go
+++ b/client.go
@@ -691,7 +691,6 @@ func (c *Client) UserAuthServerCert(name string) error {
 		Intermediates: c.scertIntermediates,
 	})
 	if err != nil {
-		fmt.Println(err)
 		fmt.Printf(gettext.Gettext("Certificate fingerprint: % x\n"), c.scertDigest)
 		fmt.Printf(gettext.Gettext("ok (y/n)? "))
 		line, err := shared.ReadStdin()

--- a/lxc/remote.go
+++ b/lxc/remote.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"net"
 	"os"
 
 	"github.com/gosexy/gettext"
@@ -40,7 +41,12 @@ func addServer(config *lxd.Config, server string, addr string) error {
 		return err
 	}
 
-	err = c.UserAuthServerCert(addr)
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		host = addr
+	}
+
+	err = c.UserAuthServerCert(host)
 	if err != nil {
 		return err
 	}

--- a/shared/network.go
+++ b/shared/network.go
@@ -1,6 +1,7 @@
 package shared
 
 import (
+	"errors"
 	"net"
 )
 
@@ -21,5 +22,5 @@ func RFC3493Dialer(network, address string) (net.Conn, error) {
 		}
 		return c, err
 	}
-	return nil, err
+	return nil, errors.New("Unable to connect to: "+address)
 }


### PR DESCRIPTION
This fixes adding a server including its port by attempting a host/port split.
It also fixes a crash I introduced earlier when adding an invalid host.
And finally it silences x509 errors since in 99% of the case people will be using self-signed certs.
